### PR TITLE
VAS: Add TC21/TC26 SKUs

### DIFF
--- a/nfc-vas/1-0/guide/about/index.html
+++ b/nfc-vas/1-0/guide/about/index.html
@@ -257,6 +257,8 @@
 <p><strong>Zebra certified Apple VAS devices:</strong> </p>
 
 <ul>
+<li>TC21 / TC26 (select SKUs)</li>
+	
 <li>TC22 / TC27</li>
 
 <li>TC53 / TC58</li>


### PR DESCRIPTION
There are a few select, custom (but still publicly available) SKUs of the TC21 and TC26 that are VAS and SmartTap certified: TC26BK-11A522-A6P (can't remember the TC21-SKU)