### PR TITLE
[DCSRFID] Remove Xamarin for RFID SDK (iOS) and (Android) tiles

### DIFF
--- a/dcs/rfid/index.html
+++ b/dcs/rfid/index.html
@@ -221,8 +221,6 @@
                                                         <li><a href="/dcs/rfid/android/2-0-2-116/guide/about/">SDK for Android</a></li>
                                                         <li><a href="/dcs/rfid/sdk-ios-rfid/about/">SDK for iOS</a></li>
                                                         <li><a href="https://techdocs.zebra.com/dcs/rfid/sdk-win-rfid/rfid-sdk/Zebra_RFID_SDK_Developer_Guide_Windows_Desktop.pdf">SDK for Windows</a></li>
-                                                        <li><a href="/dcs/rfid/xamarin/2-0-2-116/guide/about/">Xamarin for RFID SDK (Android)</a></li>
-                                                        <li><a href="/dcs/rfid/xamarin-rfid/about/">Xamarin for RFID SDK (iOS)</a></li>
                                                         <li><a href="/dcs/rfid/gen2x/">Gen2X API Reference</a></li>
                                                     </ul>
                                                 </li>
@@ -702,58 +700,6 @@
 
                 <div class="col-sm-12 col-md-6">
                     <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
-
-                        <div class="media">
-                            <div class="media-left " style="
-                          max-width: 120px;
-                          max-height: 120px;
-                          margin-right: 10px;
-                      ">
-                                <a href="#">
-                                    <i class="media-object fa fa-3x fa-xamarin"></i>
-                                </a>
-                            </div>
-                            <div class="media-body" style="
-                      padding-left: 15px;
-                      ">
-                                <div class="row">
-                                    <div class="col-sm-6 col-md-8">
-                                        <h4 class="media-heading anchor" id="-xamarin">
-                                            <a class="heading-anchor" href="#-xamarin"><span></span></a>
-                                            <a href="/dcs/rfid/xamarin/2-0-2-116/guide/about/">Xamarin for RFID SDK (Android)</a>
-                                        </h4>
-                                    </div>
-                                    <div class="col-sm-6 col-md-4 pull-right">
-                                        <div class="btn-group pull-right">
-                                            <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                                2.0.2.116&nbsp; <span class="caret"></span>
-                                            </button>
-                                            <ul class="dropdown-menu">
-                                               
-                                                    <!--<li><a href="/dcs/rfid/xamarin/2-0-2-82/guide/about">2.0.2.82</a></li>-->
-                                                    <!--<li><a href="/dcs/rfid/xamarin/2-0-2-94/guide/about">2.0.2.94</a></li>-->
-                                                    <li><a href="/dcs/rfid/xamarin/2-0-2-94/guide/about">2.0.2.110</a></li>
-													<li><a href="/dcs/rfid/xamarin/2-0-2-116/guide/about">2.0.2.116</a></li>
-                                                    <!--                                             <li><a href="/dcs/rfid/android/2-2/guide/about">2.2</a></li>
-                                            <li><a href="/dcs/rfid/android/1-5/guide/about">1.5</a></li> -->
-                                                
-                                            </ul>
-
-                                        </div>
-                                    </div>
-                                </div>
-                                <p>Handheld reader RFID API3 for Xamarin (Android)</p>
-                                <a href="/dcs/rfid/xamarin/2-0-2-116/guide/about"><span class="label label-primary">About</span></a>
-                                <a href="/dcs/rfid/xamarin/2-0-2-116/guide/gettingstarted"><span class="label label-primary">Getting Started</span></a>
-                                <a href="/dcs/rfid/xamarin/2-0-2-116/tutorials"><span class="label label-primary">Tutorials</span></a>
-                                <a href="/dcs/rfid/xamarin/2-0-2-116/samples"><span class="label label-primary">Samples</span></a>
-                            </div>				
-                        </div>
-                    </div>
-                </div>
-
-                <div class="col-sm-12 col-md-6">
-                    <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
                         <div class="media">
                             <div class="media-left " style="
                           max-width: 120px;
@@ -802,33 +748,6 @@
                     </div>
                 </div>
 		             
-                <div class="col-sm-12 col-md-6">
-                    <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
-                        <div class="media">
-                            <div class="media-left " style="
-                          max-width: 120px;
-                          max-height: 120px;
-                          margin-right: 10px;
-                      ">
-                                <a href="#">
-                                    <i class="media-object fa fa-3x fa-xamarin"></i>
-                                </a>
-                            </div>
-                            <div class="media-body" style="padding-left: 15px;">
-                                <h4 class="media-heading anchor" id="-web-services">
-                                    <a class="heading-anchor" href="#-web-services"><span></span></a> 
-                                    <a href="/dcs/rfid/xamarin-rfid/about">Xamarin for RFID SDK (iOS)</a>
-                                </h4>
-                                <p>Zebra RFID SDK for Xamarin enables a developer to build native applications to connect and control Zebra RFID readers over Bluetooth on iOS devices from a single, shared C# codebase.</p>
-                                <a href="/dcs/rfid/xamarin-rfid/about/"><span class="label label-primary">Overview</span></a>
-                                <a href="/dcs/rfid/xamarin-rfid/getting-started/"><span class="label label-primary">Getting Started</span></a>
-                                <a href="/dcs/rfid/xamarin-rfid/api/"><span class="label label-primary">API</span></a>
-								<a href="/dcs/rfid/xamarin-rfid/tutorial/"><span class="label label-primary">Tutorial</span></a>
-                            </div>						
-                        </div>
-                    </div> 
-                </div>
-					
                 <div class="col-sm-12 col-md-6">
                     <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
                         <div class="media">


### PR DESCRIPTION
Removes Xamarin for RFID SDK (iOS) and Xamarin for RFID SDK (Android) tiles and nav entries from the RFID landing page.