### PR TITLE
[DCSRFID] Reorder RFID tiles, fix icons, and update nav menu

### DIFF
--- a/dcs/rfid/index.html
+++ b/dcs/rfid/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en"><head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -218,10 +218,13 @@
                                                 </li>
                                                 <li>
                                                     <ul class="uk-nav child-tab uk-navbar-dropdown-nav uk-width-1-2">                                                         
-                                                        <li><a href="/dcs/rfid/android/2-0-2-116/guide/about/">SDK for Android</a></li>
+                                                        <li><a href="/dcs/rfid/android/2-0-5-273/guide/about/">SDK for Android</a></li>
                                                         <li><a href="/dcs/rfid/sdk-ios-rfid/about/">SDK for iOS</a></li>
                                                         <li><a href="https://techdocs.zebra.com/dcs/rfid/sdk-win-rfid/rfid-sdk/Zebra_RFID_SDK_Developer_Guide_Windows_Desktop.pdf">SDK for Windows</a></li>
+                                                        <li><a href="/dcs/rfid/maui-android/2-0-5-273/about/">MAUI for RFID SDK (Android)</a></li>
+                                                        <li><a href="/dcs/rfid/maui-ios/getting-started/">MAUI for RFID SDK (iOS)</a></li>
                                                         <li><a href="/dcs/rfid/gen2x/">Gen2X API Reference</a></li>
+                                                        <li><a href="/dcs/rfid/jposFXP20/about/">JPOS Drivers</a></li>
                                                     </ul>
                                                 </li>
                                                 <li>
@@ -649,6 +652,7 @@
     </div>
     <section id="meet-team">
         <div class="container">            
+            
             <div class="col-sm-12 col-md-6">
                 <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
                     <div class="media">
@@ -723,7 +727,6 @@
                         </div>
                     </div>
                 </div>
-            
 
                 <div class="col-sm-12 col-md-6">
                     <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
@@ -733,6 +736,9 @@
                           max-height: 120px;
                           margin-right: 10px;
                       ">
+                            <a href="#">
+                                    <i class="media-object fa fa-3x fa-windows"></i>
+                                </a>
                             </div>
                             <div class="media-body" style="padding-left: 15px;">
                                 <h4 class="media-heading anchor" id="-samples">
@@ -747,41 +753,13 @@
                         </div>
                     </div>
                 </div>
-		             
-                <div class="col-sm-12 col-md-6">
-                    <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
-                        <div class="media">
-                            <div class="media-left " style="
-                          max-width: 120px;
-                          max-height: 120px;
-                          margin-right: 10px;
-                      ">
-                                <a href="#">
-                                    <i class="media-object fa fa-3x fa-xamarin"></i>
-                                </a>
-                            </div>
-							<div class="media-body" style="padding-left: 15px;">
-                                <h4 class="media-heading anchor" id="-web-services">
-                                    <a class="heading-anchor" href="#-web-services"><span></span></a> 
-                                    <a href="maui-ios/getting-started/index.html">MAUI for RFID SDK (iOS)</a>
-                                </h4>
-                                <p>MAUI for RFID SDK on iOS</p>
-                                <!--<a href=""><span class="label label-primary">Overview</span></a>-->
-                                <a href="maui-ios/getting-started/RFID SDK for MAUI Developer Guide.pdf"><span class="label label-primary">Getting Started</span></a>
-                                <a href="maui-ios/api/index.html"><span class="label label-primary">API</span></a>
-								<a href="maui-ios/tutorial/index.html"><span class="label label-primary">Tutorial</span></a>
-								<a href="maui-ios/samples/hellorfid/index.html"><span class="label label-primary">Samples</span></a>
-                            </div>                
-                   		</div>
-					  </div>
-                    </div> 
-					
+
                     <div class="col-sm-12 col-md-6">
                         <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
                             <div class="media">
                                 <div class="media-left " style="max-width: 120px; max-height: 120px; margin-right: 10px;">
                                     <a href="#">
-                                        <i class="media-object fa fa-3x fa-xamarin"></i>
+                                        <i class="media-object fa fa-3x fa-code"></i>
                                     </a>
                                 </div>
                                 <div class="media-body" style="padding-left: 15px;">
@@ -818,7 +796,7 @@
                         </div>
                     </div>
 
-                    <div class="col-sm-12 col-md-6">
+                <div class="col-sm-12 col-md-6">
                     <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
                         <div class="media">
                             <div class="media-left " style="
@@ -827,25 +805,24 @@
                           margin-right: 10px;
                       ">
                                 <a href="#">
-                                    <i class="media-object fa fa-3x fa-xamarin"></i>
+                                    <i class="media-object fa fa-3x fa-code"></i>
                                 </a>
                             </div>
-                            <div class="media-body" style="padding-left: 15px;">
+							<div class="media-body" style="padding-left: 15px;">
                                 <h4 class="media-heading anchor" id="-web-services">
                                     <a class="heading-anchor" href="#-web-services"><span></span></a> 
-                                    <a href="/dcs/rfid/jposFXP20/about">JPOS Drivers for Windows and Linux</a>
+                                    <a href="maui-ios/getting-started/index.html">MAUI for RFID SDK (iOS)</a>
                                 </h4>
-                                <p>JPOS Drivers for Windows and Linux. An application accesses the JavaPOS device through the JavaPOS Device Interface, which is specified by Java interfaces.</p>
-                                <a href="/dcs/rfid/jposFXP20/about/index.html"><span class="label label-primary">About</span></a>
-                                <a href="/dcs/rfid/jposFXP20/getting-started/"><span class="label label-primary">Getting Started</span></a>
-                                <a href="/dcs/rfid/jposFXP20/supported-feature/"><span class="label label-primary">Properties, Methods and Events</span></a>
-                                <a href="/dcs/rfid/jposFXP20/samples/"><span class="label label-primary">Samples</span></a>
-                            </div>						
-                        </div>
+                                <p>MAUI for RFID SDK on iOS</p>
+                                <!--<a href=""><span class="label label-primary">Overview</span></a>-->
+                                <a href="maui-ios/getting-started/RFID SDK for MAUI Developer Guide.pdf"><span class="label label-primary">Getting Started</span></a>
+                                <a href="maui-ios/api/index.html"><span class="label label-primary">API</span></a>
+								<a href="maui-ios/tutorial/index.html"><span class="label label-primary">Tutorial</span></a>
+								<a href="maui-ios/samples/hellorfid/index.html"><span class="label label-primary">Samples</span></a>
+                            </div>                
+                   		</div>
+					  </div>
                     </div> 
-                </div>
-	
-
 
                 <div class="col-sm-12 col-md-6">
                     <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
@@ -879,6 +856,34 @@
                         </div>
                     </div>
                 </div>
+
+                    <div class="col-sm-12 col-md-6">
+                    <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
+                        <div class="media">
+                            <div class="media-left " style="
+                          max-width: 120px;
+                          max-height: 120px;
+                          margin-right: 10px;
+                      ">
+                                <a href="#">
+                                    <i class="media-object fa fa-3x fa-cogs"></i>
+                                </a>
+                            </div>
+                            <div class="media-body" style="padding-left: 15px;">
+                                <h4 class="media-heading anchor" id="-web-services">
+                                    <a class="heading-anchor" href="#-web-services"><span></span></a> 
+                                    <a href="/dcs/rfid/jposFXP20/about">JPOS Drivers for Windows and Linux</a>
+                                </h4>
+                                <p>JPOS Drivers for Windows and Linux. An application accesses the JavaPOS device through the JavaPOS Device Interface, which is specified by Java interfaces.</p>
+                                <a href="/dcs/rfid/jposFXP20/about/index.html"><span class="label label-primary">About</span></a>
+                                <a href="/dcs/rfid/jposFXP20/getting-started/"><span class="label label-primary">Getting Started</span></a>
+                                <a href="/dcs/rfid/jposFXP20/supported-feature/"><span class="label label-primary">Properties, Methods and Events</span></a>
+                                <a href="/dcs/rfid/jposFXP20/samples/"><span class="label label-primary">Samples</span></a>
+                            </div>						
+                        </div>
+                    </div> 
+                </div>
+
 				 
                 <!--<div class="col-sm-12 col-md-3">
                         <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">


### PR DESCRIPTION
Reorders RFID landing page tiles, fixes incorrect/missing icons, and updates the nav menu to match.

## Tile Order
1. RFID SDK for Android (fa-android)
2. RFID SDK for iOS (fa-apple)
3. RFID SDK for Windows (fa-windows -- added, was missing)
4. MAUI for RFID SDK (Android) (fa-code -- was fa-xamarin)
5. MAUI for RFID SDK (iOS) (fa-code -- was fa-xamarin)
6. Gen2X API Reference (fa-cloud)
7. JPOS Drivers for Windows and Linux (fa-cogs -- was fa-xamarin)

## Icon Fixes
- fa-xamarin does not exist in Font Awesome 4.2 (the version used on TechDocs), so these icons were never rendering
- Replaced with appropriate alternatives: fa-code for MAUI (cross-platform framework), fa-cogs for JPOS (device drivers)
- Added fa-windows icon to RFID SDK for Windows tile (previously had no icon)

## Nav Menu
- Added MAUI (Android), MAUI (iOS), and JPOS Drivers entries
- Updated SDK for Android link from 2.0.2.116 to 2.0.5.273