### PR TITLE
[DCSRFID] Move Gen2X to top, add version dropdowns to all tiles

### DIFF
--- a/dcs/rfid/index.html
+++ b/dcs/rfid/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en"><head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -218,12 +218,12 @@
                                                 </li>
                                                 <li>
                                                     <ul class="uk-nav child-tab uk-navbar-dropdown-nav uk-width-1-2">                                                         
+                                                        <li><a href="/dcs/rfid/gen2x/">Gen2X API Reference</a></li>
                                                         <li><a href="/dcs/rfid/android/2-0-5-273/guide/about/">SDK for Android</a></li>
                                                         <li><a href="/dcs/rfid/sdk-ios-rfid/about/">SDK for iOS</a></li>
                                                         <li><a href="https://techdocs.zebra.com/dcs/rfid/sdk-win-rfid/rfid-sdk/Zebra_RFID_SDK_Developer_Guide_Windows_Desktop.pdf">SDK for Windows</a></li>
                                                         <li><a href="/dcs/rfid/maui-android/2-0-5-273/about/">MAUI for RFID SDK (Android)</a></li>
                                                         <li><a href="/dcs/rfid/maui-ios/getting-started/">MAUI for RFID SDK (iOS)</a></li>
-                                                        <li><a href="/dcs/rfid/gen2x/">Gen2X API Reference</a></li>
                                                         <li><a href="/dcs/rfid/jposFXP20/about/">JPOS Drivers</a></li>
                                                     </ul>
                                                 </li>
@@ -652,7 +652,40 @@
     </div>
     <section id="meet-team">
         <div class="container">            
-            
+
+            <div class="col-sm-12 col-md-6">
+                <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
+                    <div class="media">
+                        <div class="media-left " style="max-width: 120px; max-height: 120px; margin-right: 10px;">
+                            <a href="#">
+                                <i class="media-object fa fa-3x fa-cloud"></i>
+                            </a>
+                        </div>
+                        <div class="media-body" style="padding-left: 15px;">
+                            <div class="row">
+                                <div class="col-sm-6 col-md-8">
+                                    <h4 class="media-heading anchor" id="-gen2x">
+                                        <a class="heading-anchor" href="#-gen2x"><span></span></a>
+                                        <a href="/dcs/rfid/gen2x/">Gen2X API Reference</a>
+                                    </h4>
+                                </div>
+                                <div class="col-sm-6 col-md-4 pull-right">
+                                    <div class="btn-group pull-right">
+                                        <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">1.0.0.000 <span class="caret"></span>
+                                        </button>
+                                        <ul class="dropdown-menu">
+                                            <li><a href="/dcs/rfid/gen2x/">1.0.0.000</a></li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <p>MQTT and REST API reference for Impinj Gen2X features on Zebra fixed RFID readers, including Protected Mode, FastID, TagFocus, and Tag Quieting.</p>
+                            <a href="/dcs/rfid/gen2x/"><span class="label label-primary">API Reference</span></a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <div class="col-sm-12 col-md-6">
                 <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
                     <div class="media">
@@ -661,7 +694,7 @@
                                 <i class="media-object fa fa-3x fa-android"></i>
                             </a>
                         </div>
-                        <div class="media-body" style=" padding-left: 15px;">
+                        <div class="media-body" style="padding-left: 15px;">
                             <div class="row">
                                 <div class="col-sm-6 col-md-8">
                                     <h4 class="media-heading anchor" id="-android">
@@ -681,7 +714,7 @@
                                             <li><a href="/dcs/rfid/android/2-0-4-190/guide/about">2.0.4.190</a></li>
                                             <li><a href="/dcs/rfid/android/2-0-4.177/guide/about">2.0.4.177</a></li>
                                             <li><a href="/dcs/rfid/android/2-0-3-162/guide/about">2.0.3.162</a></li>
-											<li><a href="/dcs/rfid/android/2-0-3-148/guide/about">2.0.3.148</a></li>
+                                            <li><a href="/dcs/rfid/android/2-0-3-148/guide/about">2.0.3.148</a></li>
                                             <li><a href="/dcs/rfid/android/2-0-2-124/guide/about">2.0.2.124</a></li>
                                             <li><a href="/dcs/rfid/android/2-0-2-116/guide/about">2.0.2.116</a></li>
                                             <li><a href="/dcs/rfid/android/2-0-2-110/guide/about">2.0.2.110</a></li>
@@ -702,189 +735,189 @@
                 </div>
             </div>
 
-                <div class="col-sm-12 col-md-6">
-                    <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
-                        <div class="media">
-                            <div class="media-left " style="
-                          max-width: 120px;
-                          max-height: 120px;
-                          margin-right: 10px;
-                      ">
-                                <a href="#">
-                                    <i class="media-object fa fa-3x fa-apple"></i>
-                                </a>
-                            </div>
-                            <div class="media-body" style="padding-left: 15px;">
-                                <h4 class="media-heading anchor" id="-samples">
-                                    <a class="heading-anchor" href="#-samples"><span></span></a>
-                                    <a href="/dcs/rfid/sdk-ios-rfid/about/">RFID SDK for iOS</a>
-                                </h4>
-                                <p>The Zebra RFID SDK for iOS allows developers to create native applications that connect to and manage Zebra RFID readers via Bluetooth on iOS devices..</p>
-                                <a href="/dcs/rfid/sdk-ios-rfid/about/"><span class="label label-primary">Overview</span></a>
-                                <a href="/dcs/rfid/sdk-ios-rfid/getting-started/Getting_Started_With_Zebra_Bluetooth_RFID_iOS_SDK.pdf"><span class="label label-primary">Getting Started</span></a>
-                                <a href="/dcs/rfid/sdk-ios-rfid/tutorial/"><span class="label label-primary">Tutorials</span></a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="col-sm-12 col-md-6">
-                    <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
-                        <div class="media">
-                            <div class="media-left " style="
-                          max-width: 120px;
-                          max-height: 120px;
-                          margin-right: 10px;
-                      ">
+            <div class="col-sm-12 col-md-6">
+                <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
+                    <div class="media">
+                        <div class="media-left " style="max-width: 120px; max-height: 120px; margin-right: 10px;">
                             <a href="#">
-                                    <i class="media-object fa fa-3x fa-windows"></i>
-                                </a>
+                                <i class="media-object fa fa-3x fa-apple"></i>
+                            </a>
+                        </div>
+                        <div class="media-body" style="padding-left: 15px;">
+                            <div class="row">
+                                <div class="col-sm-6 col-md-8">
+                                    <h4 class="media-heading anchor" id="-ios-sdk">
+                                        <a class="heading-anchor" href="#-ios-sdk"><span></span></a>
+                                        <a href="/dcs/rfid/sdk-ios-rfid/about/">RFID SDK for iOS</a>
+                                    </h4>
+                                </div>
+                                <div class="col-sm-6 col-md-4 pull-right">
+                                    <div class="btn-group pull-right">
+                                        <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">1.0.0.000 <span class="caret"></span>
+                                        </button>
+                                        <ul class="dropdown-menu">
+                                            <li><a href="/dcs/rfid/sdk-ios-rfid/about/">1.0.0.000</a></li>
+                                        </ul>
+                                    </div>
+                                </div>
                             </div>
-                            <div class="media-body" style="padding-left: 15px;">
-                                <h4 class="media-heading anchor" id="-windows">
-                                    <a class="heading-anchor" href="#-windows"><span></span></a>
-                                    <a href="/dcs/rfid/sdk-win-rfid/rfid-sdk/Zebra_RFID_SDK_Developer_Guide_Windows_Desktop.pdf">RFID SDK for Windows</a>
-                                </h4>
-                                <p>Zebra RFID Windows SDK enables a developer to build windows applications for Handheld readers</p>
-                                <a href="/dcs/rfid/sdk-win-rfid/rfid-sdk/Zebra_RFID_SDK_Developer_Guide_Windows_Desktop.pdf"><span class="label label-primary">RFID SDK</span></a>
-                                <a href="/dcs/rfid/sdk-win-rfid/scanner-sdk/Zebra_CoreScanner_COM_API_doc_draft1.0.0.0.pdf"><span class="label label-primary">Scanner SDK</span></a>
-                                
-                            </div>												
+                            <p>The Zebra RFID SDK for iOS allows developers to create native applications that connect to and manage Zebra RFID readers via Bluetooth on iOS devices..</p>
+                            <a href="/dcs/rfid/sdk-ios-rfid/about/"><span class="label label-primary">Overview</span></a>
+                            <a href="/dcs/rfid/sdk-ios-rfid/getting-started/Getting_Started_With_Zebra_Bluetooth_RFID_iOS_SDK.pdf"><span class="label label-primary">Getting Started</span></a>
+                            <a href="/dcs/rfid/sdk-ios-rfid/tutorial/"><span class="label label-primary">Tutorials</span></a>
                         </div>
                     </div>
                 </div>
+            </div>
 
-                    <div class="col-sm-12 col-md-6">
-                        <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
-                            <div class="media">
-                                <div class="media-left " style="max-width: 120px; max-height: 120px; margin-right: 10px;">
-                                    <a href="#">
-                                        <i class="media-object fa fa-3x fa-android"></i>
-                                    </a>
-                                </div>
-                                <div class="media-body" style="padding-left: 15px;">
-                                    <div class="row">
-                                        <div class="col-sm-6 col-md-8">
-                                            <h4 class="media-heading anchor" id="-maui-android">
-                                                <a class="heading-anchor" href="#-maui-android"><span></span></a> 
-                                                <a href="maui-android/2-0-5-273/about/index.html">MAUI for RFID SDK (Android)</a>
-                                            </h4>
-                                        </div>
-                                        <div class="col-sm-6 col-md-4 pull-right">
-                                            <div class="btn-group pull-right">
-                                                <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">2.0.5.273 <span class="caret"></span>
-                                                </button>
-                                                <ul class="dropdown-menu">
-                                                    <li><a href="maui-android/2-0-5-273/about/index.html">2.0.5.273</a></li>
-                                                    <li><a href="maui-android/2-0-5-238/about/index.html">2.0.5.238</a></li>
-                                                    <li><a href="maui-android/2-0-4-192/about/index.html">2.0.4.192</a></li>
-                                                    <li><a href="maui-android/2-0-4-190/about/index.html">2.0.4.190</a></li>
-                                                    <li><a href="maui-android/2-0-3-148/about/index.html">2.0.3.148</a></li>
-                                                    <li><a href="maui-android/1-0-209/about/index.html">1.0.209</a></li>
-                                                </ul>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <p>MAUI for RFID SDK on Android</p>
-                                    <a href="maui-android/2-0-5-273/about/index.html"><span class="label label-primary">About</span></a>
-                                    <a href="maui-android/2-0-5-273/api/index.html"><span class="label label-primary">API</span></a>
-                                    <a href="maui-android/2-0-5-273/tutorial/index.html"><span class="label label-primary">Tutorial</span></a>
-                                    <a href="maui-android/2-0-5-273/samples/hellorfid/index.html"><span class="label label-primary">Sample</span></a>
-                                    <a href="maui-android/2-0-5-273/getting-started/index.html"><span class="label label-primary">Getting Started</span></a>
-                                </div>
-                            </div>
+            <div class="col-sm-12 col-md-6">
+                <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
+                    <div class="media">
+                        <div class="media-left " style="max-width: 120px; max-height: 120px; margin-right: 10px;">
+                            <a href="#">
+                                <i class="media-object fa fa-3x fa-windows"></i>
+                            </a>
                         </div>
-                    </div>
-
-                <div class="col-sm-12 col-md-6">
-                    <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
-                        <div class="media">
-                            <div class="media-left " style="
-                          max-width: 120px;
-                          max-height: 120px;
-                          margin-right: 10px;
-                      ">
-                                <a href="#">
-                                    <i class="media-object fa fa-3x fa-apple"></i>
-                                </a>
-                            </div>
-							<div class="media-body" style="padding-left: 15px;">
-                                <h4 class="media-heading anchor" id="-maui-ios">
-                                    <a class="heading-anchor" href="#-maui-ios"><span></span></a> 
-                                    <a href="maui-ios/getting-started/index.html">MAUI for RFID SDK (iOS)</a>
-                                </h4>
-                                <p>MAUI for RFID SDK on iOS</p>
-                                <!--<a href=""><span class="label label-primary">Overview</span></a>-->
-                                <a href="maui-ios/getting-started/RFID SDK for MAUI Developer Guide.pdf"><span class="label label-primary">Getting Started</span></a>
-                                <a href="maui-ios/api/index.html"><span class="label label-primary">API</span></a>
-								<a href="maui-ios/tutorial/index.html"><span class="label label-primary">Tutorial</span></a>
-								<a href="maui-ios/samples/hellorfid/index.html"><span class="label label-primary">Samples</span></a>
-                            </div>                
-                   		</div>
-					  </div>
-                    </div> 
-
-                <div class="col-sm-12 col-md-6">
-                    <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
-                        <div class="media">
-                            <div class="media-left " style="max-width: 120px; max-height: 120px; margin-right: 10px;">
-                                <a href="#">
-                                    <i class="media-object fa fa-3x fa-cloud"></i>
-                                </a>
-                            </div>
-                            <div class="media-body" style="padding-left: 15px;">
-                                <div class="row">
-                                    <div class="col-sm-6 col-md-8">
-                                        <h4 class="media-heading anchor" id="-gen2x">
-                                            <a class="heading-anchor" href="#-gen2x"><span></span></a>
-                                            <a href="/dcs/rfid/gen2x/">Gen2X API Reference</a>
-                                        </h4>
-                                    </div>
-                                    <div class="col-sm-6 col-md-4 pull-right">
-                                        <div class="btn-group pull-right">
-                                            <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">1.0.0.000 <span class="caret"></span>
-                                            </button>
-                                            <ul class="dropdown-menu">
-                                                <li><a href="/dcs/rfid/gen2x/">1.0.0.000</a></li>
-                                            </ul>
-                                        </div>
+                        <div class="media-body" style="padding-left: 15px;">
+                            <div class="row">
+                                <div class="col-sm-6 col-md-8">
+                                    <h4 class="media-heading anchor" id="-windows">
+                                        <a class="heading-anchor" href="#-windows"><span></span></a>
+                                        <a href="/dcs/rfid/sdk-win-rfid/rfid-sdk/Zebra_RFID_SDK_Developer_Guide_Windows_Desktop.pdf">RFID SDK for Windows</a>
+                                    </h4>
+                                </div>
+                                <div class="col-sm-6 col-md-4 pull-right">
+                                    <div class="btn-group pull-right">
+                                        <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">1.0.0.000 <span class="caret"></span>
+                                        </button>
+                                        <ul class="dropdown-menu">
+                                            <li><a href="/dcs/rfid/sdk-win-rfid/rfid-sdk/Zebra_RFID_SDK_Developer_Guide_Windows_Desktop.pdf">1.0.0.000</a></li>
+                                        </ul>
                                     </div>
                                 </div>
-                                <p>MQTT and REST API reference for Impinj Gen2X features on Zebra fixed RFID readers, including Protected Mode, FastID, TagFocus, and Tag Quieting.</p>
-                                <a href="/dcs/rfid/gen2x/"><span class="label label-primary">API Reference</span></a>
                             </div>
+                            <p>Zebra RFID Windows SDK enables a developer to build windows applications for Handheld readers</p>
+                            <a href="/dcs/rfid/sdk-win-rfid/rfid-sdk/Zebra_RFID_SDK_Developer_Guide_Windows_Desktop.pdf"><span class="label label-primary">RFID SDK</span></a>
+                            <a href="/dcs/rfid/sdk-win-rfid/scanner-sdk/Zebra_CoreScanner_COM_API_doc_draft1.0.0.0.pdf"><span class="label label-primary">Scanner SDK</span></a>
                         </div>
                     </div>
                 </div>
+            </div>
 
-                    <div class="col-sm-12 col-md-6">
-                    <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
-                        <div class="media">
-                            <div class="media-left " style="
-                          max-width: 120px;
-                          max-height: 120px;
-                          margin-right: 10px;
-                      ">
-                                <a href="#">
-                                    <i class="media-object fa fa-3x fa-cogs"></i>
-                                </a>
-                            </div>
-                            <div class="media-body" style="padding-left: 15px;">
-                                <h4 class="media-heading anchor" id="-web-services">
-                                    <a class="heading-anchor" href="#-web-services"><span></span></a> 
-                                    <a href="/dcs/rfid/jposFXP20/about">JPOS Drivers for Windows and Linux</a>
-                                </h4>
-                                <p>JPOS Drivers for Windows and Linux. An application accesses the JavaPOS device through the JavaPOS Device Interface, which is specified by Java interfaces.</p>
-                                <a href="/dcs/rfid/jposFXP20/about/index.html"><span class="label label-primary">About</span></a>
-                                <a href="/dcs/rfid/jposFXP20/getting-started/"><span class="label label-primary">Getting Started</span></a>
-                                <a href="/dcs/rfid/jposFXP20/supported-feature/"><span class="label label-primary">Properties, Methods and Events</span></a>
-                                <a href="/dcs/rfid/jposFXP20/samples/"><span class="label label-primary">Samples</span></a>
-                            </div>						
+            <div class="col-sm-12 col-md-6">
+                <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
+                    <div class="media">
+                        <div class="media-left " style="max-width: 120px; max-height: 120px; margin-right: 10px;">
+                            <a href="#">
+                                <i class="media-object fa fa-3x fa-android"></i>
+                            </a>
                         </div>
-                    </div> 
+                        <div class="media-body" style="padding-left: 15px;">
+                            <div class="row">
+                                <div class="col-sm-6 col-md-8">
+                                    <h4 class="media-heading anchor" id="-maui-android">
+                                        <a class="heading-anchor" href="#-maui-android"><span></span></a> 
+                                        <a href="maui-android/2-0-5-273/about/index.html">MAUI for RFID SDK (Android)</a>
+                                    </h4>
+                                </div>
+                                <div class="col-sm-6 col-md-4 pull-right">
+                                    <div class="btn-group pull-right">
+                                        <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">2.0.5.273 <span class="caret"></span>
+                                        </button>
+                                        <ul class="dropdown-menu">
+                                            <li><a href="maui-android/2-0-5-273/about/index.html">2.0.5.273</a></li>
+                                            <li><a href="maui-android/2-0-5-238/about/index.html">2.0.5.238</a></li>
+                                            <li><a href="maui-android/2-0-4-192/about/index.html">2.0.4.192</a></li>
+                                            <li><a href="maui-android/2-0-4-190/about/index.html">2.0.4.190</a></li>
+                                            <li><a href="maui-android/2-0-3-148/about/index.html">2.0.3.148</a></li>
+                                            <li><a href="maui-android/1-0-209/about/index.html">1.0.209</a></li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <p>MAUI for RFID SDK on Android</p>
+                            <a href="maui-android/2-0-5-273/about/index.html"><span class="label label-primary">About</span></a>
+                            <a href="maui-android/2-0-5-273/api/index.html"><span class="label label-primary">API</span></a>
+                            <a href="maui-android/2-0-5-273/tutorial/index.html"><span class="label label-primary">Tutorial</span></a>
+                            <a href="maui-android/2-0-5-273/samples/hellorfid/index.html"><span class="label label-primary">Sample</span></a>
+                            <a href="maui-android/2-0-5-273/getting-started/index.html"><span class="label label-primary">Getting Started</span></a>
+                        </div>
+                    </div>
                 </div>
+            </div>
 
-				 
+            <div class="col-sm-12 col-md-6">
+                <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
+                    <div class="media">
+                        <div class="media-left " style="max-width: 120px; max-height: 120px; margin-right: 10px;">
+                            <a href="#">
+                                <i class="media-object fa fa-3x fa-apple"></i>
+                            </a>
+                        </div>
+                        <div class="media-body" style="padding-left: 15px;">
+                            <div class="row">
+                                <div class="col-sm-6 col-md-8">
+                                    <h4 class="media-heading anchor" id="-maui-ios">
+                                        <a class="heading-anchor" href="#-maui-ios"><span></span></a> 
+                                        <a href="maui-ios/getting-started/index.html">MAUI for RFID SDK (iOS)</a>
+                                    </h4>
+                                </div>
+                                <div class="col-sm-6 col-md-4 pull-right">
+                                    <div class="btn-group pull-right">
+                                        <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">1.0.0.000 <span class="caret"></span>
+                                        </button>
+                                        <ul class="dropdown-menu">
+                                            <li><a href="maui-ios/getting-started/index.html">1.0.0.000</a></li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <p>MAUI for RFID SDK on iOS</p>
+                            <a href="maui-ios/getting-started/RFID SDK for MAUI Developer Guide.pdf"><span class="label label-primary">Getting Started</span></a>
+                            <a href="maui-ios/api/index.html"><span class="label label-primary">API</span></a>
+                            <a href="maui-ios/tutorial/index.html"><span class="label label-primary">Tutorial</span></a>
+                            <a href="maui-ios/samples/hellorfid/index.html"><span class="label label-primary">Samples</span></a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-sm-12 col-md-6">
+                <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
+                    <div class="media">
+                        <div class="media-left " style="max-width: 120px; max-height: 120px; margin-right: 10px;">
+                            <a href="#">
+                                <i class="media-object fa fa-3x fa-cogs"></i>
+                            </a>
+                        </div>
+                        <div class="media-body" style="padding-left: 15px;">
+                            <div class="row">
+                                <div class="col-sm-6 col-md-8">
+                                    <h4 class="media-heading anchor" id="-jpos">
+                                        <a class="heading-anchor" href="#-jpos"><span></span></a> 
+                                        <a href="/dcs/rfid/jposFXP20/about">JPOS Drivers for Windows and Linux</a>
+                                    </h4>
+                                </div>
+                                <div class="col-sm-6 col-md-4 pull-right">
+                                    <div class="btn-group pull-right">
+                                        <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">1.0.0.000 <span class="caret"></span>
+                                        </button>
+                                        <ul class="dropdown-menu">
+                                            <li><a href="/dcs/rfid/jposFXP20/about/index.html">1.0.0.000</a></li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <p>JPOS Drivers for Windows and Linux. An application accesses the JavaPOS device through the JavaPOS Device Interface, which is specified by Java interfaces.</p>
+                            <a href="/dcs/rfid/jposFXP20/about/index.html"><span class="label label-primary">About</span></a>
+                            <a href="/dcs/rfid/jposFXP20/getting-started/"><span class="label label-primary">Getting Started</span></a>
+                            <a href="/dcs/rfid/jposFXP20/supported-feature/"><span class="label label-primary">Properties, Methods and Events</span></a>
+                            <a href="/dcs/rfid/jposFXP20/samples/"><span class="label label-primary">Samples</span></a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
                 <!--<div class="col-sm-12 col-md-3">
                         <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
 


### PR DESCRIPTION
Changes to /dcs/rfid/index.html:

Moved the Gen2X API Reference tile to the first position on the RFID landing page
Added version dropdown (1.0.0.000) to four tiles that were missing one:
RFID SDK for iOS
RFID SDK for Windows
MAUI for RFID SDK (iOS)
JPOS Drivers for Windows and Linux
Normalized all tile HTML to use consistent indentation and the same row+dropdown layout structure
Updated the nav menu order to match the new tile order (Gen2X first)