### PR TITLE
[DCSRFID] Improve RFID landing page tile descriptions

### DIFF
--- a/dcs/rfid/index.html
+++ b/dcs/rfid/index.html
@@ -721,7 +721,7 @@
                                             <li><a href="/dcs/rfid/android/4-0-0-9/guide/about">4.0.0.9</a></li>
                                         </ul>
                                     </div>
-                                </div>
+                               Android SDK (.aar library) for building RFID applications on Zebra handheld readers, mobile computers, and fixed readers. Includes API reference, programming guides, tutorials, and sample projects.
                             </div>
                             <p>Handheld reader and Fixed reader Android SDK includes API documentation and sample projects using RFID API3</p>
                             <a href="/dcs/rfid/android/2-0-5-273/guide/about"><span class="label label-primary">About</span></a>
@@ -794,7 +794,7 @@
                                             <li><a href="/dcs/rfid/sdk-win-rfid/rfid-sdk/Zebra_RFID_SDK_Developer_Guide_Windows_Desktop.pdf">1.0.0.000</a></li>
                                         </ul>
                                     </div>
-                                </div>
+                               Windows desktop developer guides for building RFID applications with Zebra handheld readers. Includes RFID SDK and CoreScanner COM API documentation.
                             </div>
                             <p>Zebra RFID Windows SDK enables a developer to build windows applications for Handheld readers</p>
                             <a href="/dcs/rfid/sdk-win-rfid/rfid-sdk/Zebra_RFID_SDK_Developer_Guide_Windows_Desktop.pdf"><span class="label label-primary">RFID SDK</span></a>
@@ -833,7 +833,7 @@
                                             <li><a href="maui-android/1-0-209/about/index.html">1.0.209</a></li>
                                         </ul>
                                     </div>
-                                </div>
+                               .NET MAUI SDK for building cross-platform RFID applications on Android with Zebra handheld readers and mobile computers. Includes API reference, tutorials, and sample projects.
                             </div>
                             <p>MAUI for RFID SDK on Android</p>
                             <a href="maui-android/2-0-5-273/about/index.html"><span class="label label-primary">About</span></a>
@@ -870,7 +870,7 @@
                                             <li><a href="maui-ios/getting-started/index.html">1.0.0.000</a></li>
                                         </ul>
                                     </div>
-                                </div>
+                               .NET MAUI SDK for building cross-platform RFID applications on iOS with Zebra Bluetooth handheld readers. Includes programmer's guide, API reference, tutorials, and sample projects.
                             </div>
                             <p>MAUI for RFID SDK on iOS</p>
                             <a href="maui-ios/getting-started/RFID SDK for MAUI Developer Guide.pdf"><span class="label label-primary">Getting Started</span></a>
@@ -906,7 +906,7 @@
                                             <li><a href="/dcs/rfid/jposFXP20/about/index.html">1.0.0.000</a></li>
                                         </ul>
                                     </div>
-                                </div>
+                                avaPOS (UPOS-compliant) RFID scanner drivers for the FXP20 fixed reader, enabling integration with retail point-of-sale applications on Windows and Linux
                             </div>
                             <p>JPOS Drivers for Windows and Linux. An application accesses the JavaPOS device through the JavaPOS Device Interface, which is specified by Java interfaces.</p>
                             <a href="/dcs/rfid/jposFXP20/about/index.html"><span class="label label-primary">About</span></a>


### PR DESCRIPTION
Rewrites 5 SDK tile descriptions on the RFID landing page to be more informative and accurate.

- **Android SDK** — Replace internal "RFID API3" jargon with clear scope (handheld readers, mobile computers, fixed readers)
- **Windows SDK** — Fix capitalization, mention both RFID SDK and CoreScanner COM API documentation
- **MAUI Android** — Replace title restatement with .NET MAUI context, supported devices, and feature list
- **MAUI iOS** — Same treatment, noting Bluetooth connectivity and included content
- **JPOS** — Replace circular JavaPOS jargon with UPOS standard, FXP20 device, and retail POS context