### PR TITLE
[DCSRFID] Fix corrupted HTML from bad merge of tile descriptions PR

### DIFF
--- a/dcs/rfid/index.html
+++ b/dcs/rfid/index.html
@@ -719,9 +719,9 @@
                                             <li><a href="/dcs/rfid/android/4-0-0-9/guide/about/">4.0.0.9</a></li>
                                         </ul>
                                     </div>
-                               Android SDK (.aar library) for building RFID applications on Zebra handheld readers, mobile computers, and fixed readers. Includes API reference, programming guides, tutorials, and sample projects.
+                                </div>
                             </div>
-                            <p>Handheld reader and Fixed reader Android SDK includes API documentation and sample projects using RFID API3</p>
+                            <p>Android SDK (.aar library) for building RFID applications on Zebra handheld readers, mobile computers, and fixed readers. Includes API reference, programming guides, tutorials, and sample projects.</p>
                             <a href="/dcs/rfid/android/2-0-5-273/guide/about/"><span class="label label-primary">About</span></a>
                             <a href="/dcs/rfid/android/2-0-5-273/guide/gettingstarted/"><span class="label label-primary">Getting Started</span></a>
                             <a href="/dcs/rfid/android/2-0-5-273/guide/programming-guides/"><span class="label label-primary">Guide</span></a>
@@ -792,9 +792,9 @@
                                             <li><a href="/dcs/rfid/sdk-win-rfid/rfid-sdk/Zebra_RFID_SDK_Developer_Guide_Windows_Desktop.pdf">1.0.0.000</a></li>
                                         </ul>
                                     </div>
-                               Windows desktop developer guides for building RFID applications with Zebra handheld readers. Includes RFID SDK and CoreScanner COM API documentation.
+                                </div>
                             </div>
-                            <p>Zebra RFID Windows SDK enables a developer to build windows applications for Handheld readers</p>
+                            <p>Windows desktop developer guides for building RFID applications with Zebra handheld readers. Includes RFID SDK and CoreScanner COM API documentation.</p>
                             <a href="/dcs/rfid/sdk-win-rfid/rfid-sdk/Zebra_RFID_SDK_Developer_Guide_Windows_Desktop.pdf"><span class="label label-primary">RFID SDK</span></a>
                             <a href="/dcs/rfid/sdk-win-rfid/scanner-sdk/Zebra_CoreScanner_COM_API_doc_draft1.0.0.0.pdf"><span class="label label-primary">Scanner SDK</span></a>
                         </div>
@@ -831,9 +831,9 @@
                                             <li><a href="/dcs/rfid/maui-android/1-0-209/about/index.html">1.0.209</a></li>
                                         </ul>
                                     </div>
-                               .NET MAUI SDK for building cross-platform RFID applications on Android with Zebra handheld readers and mobile computers. Includes API reference, tutorials, and sample projects.
+                                </div>
                             </div>
-                            <p>MAUI for RFID SDK on Android</p>
+                            <p>.NET MAUI SDK for building cross-platform RFID applications on Android with Zebra handheld readers and mobile computers. Includes API reference, tutorials, and sample projects.</p>
                             <a href="/dcs/rfid/maui-android/2-0-5-273/about/index.html"><span class="label label-primary">About</span></a>
                             <a href="/dcs/rfid/maui-android/2-0-5-273/getting-started/index.html"><span class="label label-primary">Getting Started</span></a>
                             <a href="/dcs/rfid/maui-android/2-0-5-273/tutorial/index.html"><span class="label label-primary">Tutorials</span></a>
@@ -868,9 +868,9 @@
                                             <li><a href="/dcs/rfid/maui-ios/getting-started/index.html">1.0.0.000</a></li>
                                         </ul>
                                     </div>
-                               .NET MAUI SDK for building cross-platform RFID applications on iOS with Zebra Bluetooth handheld readers. Includes programmer's guide, API reference, tutorials, and sample projects.
+                                </div>
                             </div>
-                            <p>MAUI for RFID SDK on iOS</p>
+                            <p>.NET MAUI SDK for building cross-platform RFID applications on iOS with Zebra Bluetooth handheld readers. Includes programmer's guide, API reference, tutorials, and sample projects.</p>
                             <a href="/dcs/rfid/maui-ios/getting-started/RFID%20SDK%20for%20MAUI%20Developer%20Guide.pdf"><span class="label label-primary">Getting Started</span></a>
                             <a href="/dcs/rfid/maui-ios/tutorial/index.html"><span class="label label-primary">Tutorials</span></a>
                             <a href="/dcs/rfid/maui-ios/samples/hellorfid/index.html"><span class="label label-primary">Samples</span></a>
@@ -904,9 +904,9 @@
                                             <li><a href="/dcs/rfid/jposFXP20/about/index.html">1.0.0.000</a></li>
                                         </ul>
                                     </div>
-                                avaPOS (UPOS-compliant) RFID scanner drivers for the FXP20 fixed reader, enabling integration with retail point-of-sale applications on Windows and Linux
+                                </div>
                             </div>
-                            <p>JPOS Drivers for Windows and Linux. An application accesses the JavaPOS device through the JavaPOS Device Interface, which is specified by Java interfaces.</p>
+                            <p>JavaPOS (UPOS-compliant) RFID scanner drivers for the FXP20 fixed reader, enabling integration with retail point-of-sale applications on Windows and Linux.</p>
                             <a href="/dcs/rfid/jposFXP20/about/index.html"><span class="label label-primary">About</span></a>
                             <a href="/dcs/rfid/jposFXP20/getting-started/"><span class="label label-primary">Getting Started</span></a>
                             <a href="/dcs/rfid/jposFXP20/supported-feature/"><span class="label label-primary">Properties, Methods and Events</span></a>


### PR DESCRIPTION
Fixes broken HTML caused by a bad auto-merge of PR #71 into master.

GitHub's merge replaced </div> closing tags with raw description text in 5 tiles,
breaking the Bootstrap grid layout. This restores the </div> tags and places the
new descriptions in the correct <p> elements.