### PR TITLE
[DCSRFID] Rename Gen2X tile and move to bottom of landing page

### DIFF
--- a/dcs/rfid/index.html
+++ b/dcs/rfid/index.html
@@ -215,7 +215,7 @@
                                                 </li>
                                                 <li>
                                                     <ul class="uk-nav child-tab uk-navbar-dropdown-nav uk-width-1-2">                                                         
-                                                        <li><a href="/dcs/rfid/gen2x/">Gen2X API Reference</a></li>
+                                                        <li><a href="/dcs/rfid/gen2x/">Fixed Reader Gen2X API Reference</a></li>
                                                         <li><a href="/dcs/rfid/android/2-0-5-273/guide/about/">SDK for Android</a></li>
                                                         <li><a href="/dcs/rfid/sdk-ios-rfid/about/">SDK for iOS</a></li>
                                                         <li><a href="/dcs/rfid/sdk-win-rfid/rfid-sdk/Zebra_RFID_SDK_Developer_Guide_Windows_Desktop.pdf">SDK for Windows</a></li>
@@ -655,39 +655,6 @@
                 <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
                     <div class="media">
                         <div class="media-left " style="max-width: 120px; max-height: 120px; margin-right: 10px;">
-                            <a href="/dcs/rfid/gen2x/" aria-label="Gen2X API Reference">
-                                <i class="media-object fa fa-3x fa-cloud"></i>
-                            </a>
-                        </div>
-                        <div class="media-body" style="padding-left: 15px;">
-                            <div class="row">
-                                <div class="col-sm-6 col-md-8">
-                                    <h4 class="media-heading anchor" id="-gen2x">
-                                        <a class="heading-anchor" href="#-gen2x"><span></span></a>
-                                        <a href="/dcs/rfid/gen2x/">Gen2X API Reference</a>
-                                    </h4>
-                                </div>
-                                <div class="col-sm-6 col-md-4 pull-right">
-                                    <div class="btn-group pull-right">
-                                        <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">1.0.0.000 <span class="caret"></span>
-                                        </button>
-                                        <ul class="dropdown-menu">
-                                            <li><a href="/dcs/rfid/gen2x/">1.0.0.000</a></li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                            <p>MQTT and REST API reference for Impinj Gen2X features on Zebra fixed RFID readers, including Protected Mode, FastID, TagFocus, and Tag Quieting.</p>
-                            <a href="/dcs/rfid/gen2x/"><span class="label label-primary">API Reference</span></a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="col-sm-12 col-md-6">
-                <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
-                    <div class="media">
-                        <div class="media-left " style="max-width: 120px; max-height: 120px; margin-right: 10px;">
                             <a href="/dcs/rfid/android/2-0-5-273/guide/about/" aria-label="RFID SDK for Android">
                                 <i class="media-object fa fa-3x fa-android"></i>
                             </a>
@@ -911,6 +878,39 @@
                             <a href="/dcs/rfid/jposFXP20/getting-started/"><span class="label label-primary">Getting Started</span></a>
                             <a href="/dcs/rfid/jposFXP20/supported-feature/"><span class="label label-primary">Properties, Methods and Events</span></a>
                             <a href="/dcs/rfid/jposFXP20/samples/"><span class="label label-primary">Samples</span></a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-sm-12 col-md-6">
+                <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
+                    <div class="media">
+                        <div class="media-left " style="max-width: 120px; max-height: 120px; margin-right: 10px;">
+                            <a href="/dcs/rfid/gen2x/" aria-label="Fixed Reader Gen2X API Reference">
+                                <i class="media-object fa fa-3x fa-cloud"></i>
+                            </a>
+                        </div>
+                        <div class="media-body" style="padding-left: 15px;">
+                            <div class="row">
+                                <div class="col-sm-6 col-md-8">
+                                    <h4 class="media-heading anchor" id="-gen2x">
+                                        <a class="heading-anchor" href="#-gen2x"><span></span></a>
+                                        <a href="/dcs/rfid/gen2x/">Fixed Reader Gen2X API Reference</a>
+                                    </h4>
+                                </div>
+                                <div class="col-sm-6 col-md-4 pull-right">
+                                    <div class="btn-group pull-right">
+                                        <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">1.0.0.000 <span class="caret"></span>
+                                        </button>
+                                        <ul class="dropdown-menu">
+                                            <li><a href="/dcs/rfid/gen2x/">1.0.0.000</a></li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <p>MQTT and REST API reference for Impinj Gen2X features on Zebra fixed RFID readers, including Protected Mode, FastID, TagFocus, and Tag Quieting.</p>
+                            <a href="/dcs/rfid/gen2x/"><span class="label label-primary">API Reference</span></a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
- Rename "Gen2X API Reference" to "Fixed Reader Gen2X API Reference" (tile heading, nav entry, and aria-label)
- Move the tile from the first position to the last (after JPOS Drivers)