### PR TITLE
[DCSRFID] Remove version dropdown from Fixed Reader Gen2X tile

### DIFF
--- a/dcs/rfid/index.html
+++ b/dcs/rfid/index.html
@@ -892,23 +892,10 @@
                             </a>
                         </div>
                         <div class="media-body" style="padding-left: 15px;">
-                            <div class="row">
-                                <div class="col-sm-6 col-md-8">
-                                    <h4 class="media-heading anchor" id="-gen2x">
-                                        <a class="heading-anchor" href="#-gen2x"><span></span></a>
-                                        <a href="/dcs/rfid/gen2x/">Fixed Reader Gen2X API Reference</a>
-                                    </h4>
-                                </div>
-                                <div class="col-sm-6 col-md-4 pull-right">
-                                    <div class="btn-group pull-right">
-                                        <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">1.0.0.000 <span class="caret"></span>
-                                        </button>
-                                        <ul class="dropdown-menu">
-                                            <li><a href="/dcs/rfid/gen2x/">1.0.0.000</a></li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
+                            <h4 class="media-heading anchor" id="-gen2x">
+                                <a class="heading-anchor" href="#-gen2x"><span></span></a>
+                                <a href="/dcs/rfid/gen2x/">Fixed Reader Gen2X API Reference</a>
+                            </h4>
                             <p>MQTT and REST API reference for Impinj Gen2X features on Zebra fixed RFID readers, including Protected Mode, FastID, TagFocus, and Tag Quieting.</p>
                             <a href="/dcs/rfid/gen2x/"><span class="label label-primary">API Reference</span></a>
                         </div>


### PR DESCRIPTION
Remove the version number dropdown (showing "1.0.0.000") from the Fixed Reader Gen2X API Reference tile. This API reference is a single unversioned document, so the version selector is unnecessary and misleading.