### PR TITLE
Rename Gen2X tile to 'Fixed Reader APIs' with 'Gen2X APIs' badge

### DIFF
--- a/dcs/rfid/index.html
+++ b/dcs/rfid/index.html
@@ -215,7 +215,7 @@
                                                 </li>
                                                 <li>
                                                     <ul class="uk-nav child-tab uk-navbar-dropdown-nav uk-width-1-2">                                                         
-                                                        <li><a href="/dcs/rfid/gen2x/">Fixed Reader Gen2X API Reference</a></li>
+                                                        <li><a href="/dcs/rfid/gen2x/">Fixed Reader APIs</a></li>
                                                         <li><a href="/dcs/rfid/android/2-0-5-273/guide/about/">SDK for Android</a></li>
                                                         <li><a href="/dcs/rfid/sdk-ios-rfid/about/">SDK for iOS</a></li>
                                                         <li><a href="/dcs/rfid/sdk-win-rfid/rfid-sdk/Zebra_RFID_SDK_Developer_Guide_Windows_Desktop.pdf">SDK for Windows</a></li>
@@ -887,17 +887,17 @@
                 <div class="team-member wow fadeInUp" data-wow-duration="400ms" data-wow-delay="0ms">
                     <div class="media">
                         <div class="media-left " style="max-width: 120px; max-height: 120px; margin-right: 10px;">
-                            <a href="/dcs/rfid/gen2x/" aria-label="Fixed Reader Gen2X API Reference">
+                            <a href="/dcs/rfid/gen2x/" aria-label="Fixed Reader APIs">
                                 <i class="media-object fa fa-3x fa-cloud"></i>
                             </a>
                         </div>
                         <div class="media-body" style="padding-left: 15px;">
                             <h4 class="media-heading anchor" id="-gen2x">
                                 <a class="heading-anchor" href="#-gen2x"><span></span></a>
-                                <a href="/dcs/rfid/gen2x/">Fixed Reader Gen2X API Reference</a>
+                                <a href="/dcs/rfid/gen2x/">Fixed Reader APIs</a>
                             </h4>
                             <p>MQTT and REST API reference for Impinj Gen2X features on Zebra fixed RFID readers, including Protected Mode, FastID, TagFocus, and Tag Quieting.</p>
-                            <a href="/dcs/rfid/gen2x/"><span class="label label-primary">API Reference</span></a>
+                            <a href="/dcs/rfid/gen2x/"><span class="label label-primary">Gen2X APIs</span></a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Changes:
Renames the tile heading from Fixed Reader Gen2X API Reference to Fixed Reader APIs (shorter, future-proof for additional fixed-reader API sets)
Renames the badge from API Reference to Gen2X APIs (clarifies that this specific link targets the Gen2X feature set)
Updates the navigation sidebar link to match

Rationale:
The broader "Fixed Reader APIs" title leaves room for future fixed-reader documentation (e.g., IoTC core APIs, access operations) while the "Gen2X APIs" badge keeps the specific scope visible at a glance.