### PR TITLE
Update Fixed Reader APIs tile: broadcast-tower icon and broader description

### DIFF
--- a/dcs/rfid/index.html
+++ b/dcs/rfid/index.html
@@ -888,7 +888,7 @@
                     <div class="media">
                         <div class="media-left " style="max-width: 120px; max-height: 120px; margin-right: 10px;">
                             <a href="/dcs/rfid/gen2x/" aria-label="Fixed Reader APIs">
-                                <i class="media-object fa fa-3x fa-cloud"></i>
+                                <i class="media-object fa fa-3x fa-broadcast-tower"></i>
                             </a>
                         </div>
                         <div class="media-body" style="padding-left: 15px;">
@@ -896,7 +896,7 @@
                                 <a class="heading-anchor" href="#-gen2x"><span></span></a>
                                 <a href="/dcs/rfid/gen2x/">Fixed Reader APIs</a>
                             </h4>
-                            <p>MQTT and REST API reference for Impinj Gen2X features on Zebra fixed RFID readers, including Protected Mode, FastID, TagFocus, and Tag Quieting.</p>
+                            <p>API documentation for Zebra fixed RFID readers. Configure and control advanced reader features through MQTT and REST interfaces.</p>
                             <a href="/dcs/rfid/gen2x/"><span class="label label-primary">Gen2X APIs</span></a>
                         </div>
                     </div>


### PR DESCRIPTION
Changes:
Replaces tile icon from fa-cloud → fa-broadcast-tower to visually represent a stationary RFID reader radiating RF signal
Replaces the description with a broader, future-proof summary: "API documentation for Zebra fixed RFID readers. Configure and control advanced reader features through MQTT and REST interfaces."

Rationale:
The fa-broadcast-tower icon clearly communicates fixed RF infrastructure and will contrast well with a future handheld reader tile. The updated description avoids listing individual Gen2X features so it remains accurate as additional API sets are added under this tile.